### PR TITLE
Investigate login redirect error and dao model impact

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,0 +1,113 @@
+# Current Working Features
+
+This document summarizes the features that are implemented and routable in the current project, with their routes, access controls, and brief usage notes.
+
+## Authentication
+- Login page (HTML)
+  - GET `/login`
+  - Renders the login form. If already authenticated with a valid role, redirects to the role dashboard.
+
+- Login (API)
+  - POST `/api/auth/login`
+  - Body: `school_id`, `password`
+  - On success: session is initialized and user is redirected (by controller) to the role dashboard.
+  - On failure: login page is re-rendered with error.
+
+- Logout (API)
+  - POST `/api/auth/logout`
+  - Returns JSON success message and clears user session.
+
+- Root redirect
+  - GET `/`
+  - Redirects to `/login`.
+
+## Role-Based Dashboards
+- Admin dashboard (HTML)
+  - GET `/admin/dashboard`
+  - Access: authenticated users with role `admin` (enforced by controller constructor via `requireAuth()` + `requireRole('admin')`).
+  - Displays admin panel with student and faculty listings (via `UserService`).
+
+- Faculty dashboard (HTML)
+  - GET `/faculty/dashboard`
+  - Access: authenticated users with role `faculty` (enforced by controller constructor).
+
+- Student success placeholder (HTML)
+  - GET `/student-success`
+  - Basic success page shown after student login (placeholder until a full student dashboard exists).
+
+## Logout (Confirmation Flows)
+- Admin logout confirmation + action
+  - GET `/admin/logout` (renders confirmation page)
+  - GET `/admin/logout?confirm=true` (performs logout then redirects to `/login`)
+
+- Faculty logout confirmation + action
+  - GET `/faculty/logout` (renders confirmation page)
+  - GET `/faculty/logout?confirm=true` (performs logout then redirects to `/login`)
+
+## Admin User Management (CRUD)
+All routes require role `admin` (enforced by `AdminController` constructor).
+
+- Add generic user
+  - POST `/admin/users/add`
+  - Creates a user via `UserService::createUser()`.
+
+- Add student
+  - POST `/admin/users/add-student`
+  - Creates a student user (role `student`).
+
+- Edit student
+  - POST `/admin/users/edit-student`
+  - Updates an existing student.
+
+- Delete student
+  - POST `/admin/users/delete-student`
+  - Deletes a student.
+
+- Add faculty
+  - POST `/admin/users/add-faculty`
+  - Creates a faculty user (role `faculty`).
+
+- Edit faculty
+  - POST `/admin/users/edit-faculty`
+  - Updates an existing faculty member.
+
+- Delete faculty
+  - POST `/admin/users/delete-faculty`
+  - Deletes a faculty member.
+
+- Edit user by id (generic)
+  - POST `/admin/users/edit/{id}`
+
+- Delete user by id (generic)
+  - POST `/admin/users/delete/{id}`
+
+Notes:
+- Admin actions set success/error messages (via session) and redirect back to the dashboard.
+- `UserService` and `UserDAO` handle business rules, validation, and persistence.
+
+## Services and Core Behaviors
+- Session-based authentication
+  - `AuthService::login()` sets `$_SESSION` keys: `user_id`, `school_id`, `full_name`, `role`, optionally `year_level`, `section`.
+  - `AuthService::logout()` clears session and cookie.
+  - `AuthService::requireAuth()` and `requireRole($role)` redirect unauthenticated/unauthorized users to `/login`.
+
+- User business logic
+  - `User` model encapsulates validation, password hashing/verification, and conversion to array.
+  - `UserService` provides higher-level methods: create, update, delete, list by role, list students by year/section, etc.
+
+## Routing and Base Path Handling
+- `public/index.php` registers all routes and uses a custom `Router` that normalizes paths and supports subdirectory deployments.
+- Protected controllers (`AdminController`, `FacultyController`) are instantiated lazily inside route handlers to avoid constructor-time redirects on `/login`.
+
+## Database
+- Backed by MySQL `users` table.
+- `UserDAO` uses prepared statements and returns `User` model instances.
+
+## Summary
+The application currently supports:
+- Authentication (login/logout)
+- Role-based access control
+- Admin dashboard and CRUD for users (students/faculty)
+- Faculty dashboard
+- Student success placeholder page
+- Robust routing with subdirectory support and session-backed authorization.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,624 @@
+# PHP Examination System - TDD Red-Green-Refactor Documentation
+
+## Table of Contents
+- Feature 1: User Authentication (Login System)
+- Feature 2: Admin User Management (CRUD Operations)
+- Feature 3: Role-Based Dashboard Access
+- TDD Benefits Observed
+- Integration with IDE (Cursor/PHPStorm)
+- Next Steps and Recommendations
+
+## Feature 1: User Authentication System
+
+### 🔴 RED Phase: Write Failing Tests
+
+#### Unit: AuthService
+```php
+<?php
+
+use PHPUnit\Framework\TestCase;
+use App\Services\Auth\AuthService;
+use App\DAO\Auth\UserDAO;
+use App\Models\User;
+
+class AuthServiceRgrTest extends TestCase
+{
+    private AuthService $authService;
+    private $userDAOMock;
+
+    protected function setUp(): void
+    {
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_destroy();
+        }
+        $_SESSION = [];
+
+        $this->userDAOMock = $this->createMock(UserDAO::class);
+        $this->authService = new AuthService($this->userDAOMock);
+    }
+
+    public function test_login_success_sets_session_and_returns_user()
+    {
+        $user = new User([
+            'user_id' => 10,
+            'school_id' => 'A123',
+            'full_name' => 'Alice Admin',
+            'role' => 'admin',
+            'password' => password_hash('secret', PASSWORD_BCRYPT),
+        ]);
+
+        $this->userDAOMock->method('authenticate')
+            ->with('A123', 'secret')
+            ->willReturn($user);
+
+        $result = $this->authService->login('A123', 'secret');
+
+        $this->assertTrue($result['success']);
+        $this->assertSame('admin', $_SESSION['role'] ?? null);
+        $this->assertSame('A123', $_SESSION['school_id'] ?? null);
+    }
+
+    public function test_login_fails_for_wrong_password()
+    {
+        $user = new User([
+            'user_id' => 10,
+            'school_id' => 'A123',
+            'full_name' => 'Alice Admin',
+            'role' => 'admin',
+            'password' => password_hash('secret', PASSWORD_BCRYPT),
+        ]);
+
+        $this->userDAOMock->method('authenticate')
+            ->with('A123', 'bad')
+            ->willReturn($user);
+
+        $result = $this->authService->login('A123', 'bad');
+
+        $this->assertFalse($result['success']);
+        $this->assertSame('Invalid School ID or password.', $result['message']);
+    }
+
+    public function test_login_fails_when_user_not_found()
+    {
+        $this->userDAOMock->method('authenticate')
+            ->with('NONE', 'pw')
+            ->willReturn(null);
+
+        $result = $this->authService->login('NONE', 'pw');
+
+        $this->assertFalse($result['success']);
+        $this->assertSame('User not found.', $result['message']);
+    }
+
+    public function test_login_fails_when_empty_credentials()
+    {
+        $this->assertFalse($this->authService->login('', 'pw')['success']);
+        $this->assertFalse($this->authService->login('id', '')['success']);
+        $this->assertFalse($this->authService->login('', '')['success']);
+    }
+
+    public function test_require_auth_redirects_when_not_authenticated()
+    {
+        $this->expectOutputRegex('/.*/');
+        try {
+            $this->authService->requireAuth();
+            $this->fail('Expected exit() in requireAuth');
+        } catch (\Throwable $e) {
+            $this->assertTrue(true);
+        }
+    }
+}
+```
+
+#### Integration: AuthController
+```php
+<?php
+
+use PHPUnit\Framework\TestCase;
+use App\Controllers\Auth\AuthController;
+
+class AuthControllerRgrTest extends TestCase
+{
+    private AuthController $controller;
+
+    protected function setUp(): void
+    {
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
+        $_SESSION = [];
+        $_SERVER['SCRIPT_NAME'] = '/index.php';
+        $this->controller = new AuthController();
+    }
+
+    public function test_get_login_shows_login_page()
+    {
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        ob_start();
+        $this->controller->showLogin();
+        $html = ob_get_clean();
+        $this->assertStringContainsString('Login', $html);
+    }
+
+    public function test_post_login_success_redirects_to_role_dashboard()
+    {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $_POST['school_id'] = 'A123';
+        $_POST['password'] = 'secret';
+
+        ob_start();
+        $this->controller->login();
+        ob_end_clean();
+
+        $this->assertTrue(true);
+    }
+
+    public function test_post_login_invalid_credentials_rerenders_login_with_error()
+    {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $_POST['school_id'] = 'A123';
+        $_POST['password'] = 'wrong';
+
+        ob_start();
+        $this->controller->login();
+        $html = ob_get_clean();
+
+        $this->assertStringContainsString('Login', $html);
+    }
+
+    public function test_post_login_missing_fields_rerenders_with_error()
+    {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $_POST['school_id'] = '';
+        $_POST['password'] = '';
+
+        ob_start();
+        $this->controller->login();
+        $html = ob_get_clean();
+
+        $this->assertStringContainsString('required', $html);
+    }
+
+    public function test_logout_returns_json_success()
+    {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        ob_start();
+        $this->controller->logout();
+        $json = ob_get_clean();
+        $this->assertStringContainsString('success', $json);
+    }
+}
+```
+
+#### DAO: Database Interaction (Unit with doubles)
+```php
+<?php
+
+use PHPUnit\Framework\TestCase;
+use App\DAO\Auth\UserDAO;
+use App\Models\User;
+
+class UserDAORgrTest extends TestCase
+{
+    public function test_find_by_school_id_returns_user_model()
+    {
+        $dao = new UserDAO();
+        $this->assertTrue(method_exists($dao, 'findBySchoolId'));
+    }
+
+    public function test_authenticate_returns_user_model_or_null()
+    {
+        $dao = new UserDAO();
+        $this->assertTrue(method_exists($dao, 'authenticate'));
+    }
+}
+```
+
+Example failing output (abbreviated):
+```text
+PHPUnit 10.x by Sebastian Bergmann and contributors.
+
+FFFFF.....  10 / 10 (100%)
+
+Failures:
+1) AuthServiceRgrTest::test_login_success_sets_session_and_returns_user
+Failed asserting that true is false. ...
+
+2) AuthServiceRgrTest::test_login_fails_for_wrong_password
+Failed asserting that false is true. ...
+```
+
+### 🟢 GREEN Phase: Make Tests Pass
+
+- Model: `User::verifyPassword()` supports plaintext and hashed verification.
+```php
+public function verifyPassword(string $plain): bool
+{
+    $hashed = $this->password ?? '';
+    if ($hashed && password_get_info($hashed)['algo']) {
+        return password_verify($plain, $hashed);
+    }
+    return $plain === $hashed || $plain === ($this->plain_password ?? '');
+}
+```
+
+- DAO: `authenticate()` delegates to `findBySchoolId()` and returns a `User` model or null.
+```php
+public function authenticate($school_id, $password): ?User
+{
+    return $this->findBySchoolId($school_id);
+}
+```
+
+- Service: Minimal login.
+```php
+public function login($school_id, $password)
+{
+    if (empty(trim($school_id)) || empty(trim($password))) {
+        return ['success' => false, 'message' => 'School ID and password are required.'];
+    }
+    $user = $this->userDAO->authenticate(trim($school_id), trim($password));
+    if (!$user) {
+        return ['success' => false, 'message' => 'User not found.'];
+    }
+    if (!$user->verifyPassword($password)) {
+        return ['success' => false, 'message' => 'Invalid School ID or password.'];
+    }
+    if (session_status() === PHP_SESSION_NONE) session_start();
+    $_SESSION['user_id'] = $user->getUserId();
+    $_SESSION['school_id'] = $user->getSchoolId();
+    $_SESSION['full_name'] = $user->getFullName();
+    $_SESSION['role'] = $user->getRole();
+    return ['success' => true, 'message' => 'Login successful!', 'user' => $user->toArray()];
+}
+```
+
+- Controller: Minimal login handling.
+```php
+public function login()
+{
+    if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+        $this->showLogin();
+        return;
+    }
+    $school_id = $_POST['school_id'] ?? '';
+    $password = $_POST['password'] ?? '';
+    $result = $this->authService->login($school_id, $password);
+    if ($result['success']) {
+        $this->redirectToDashboard($result['user']['role']);
+    } else {
+        $this->view->display('auth.login', ['error' => $result['message']]);
+    }
+}
+```
+
+### 🔵 REFACTOR Phase: Production Code
+
+- Input sanitization, error handling, secure password hashing.
+- DAO returns `User` models via prepared statements (SQL injection prevention).
+- Robust session management, `requireAuth()/requireRole()` with base-path-aware redirects.
+- Dependency injection of `UserDAOInterface` into services.
+- Guard against invalid roles to prevent redirect loops.
+
+---
+
+## Feature 2: Admin User Management (CRUD Operations)
+
+### 🔴 RED Phase: Write Failing Tests
+
+#### Unit: UserService
+```php
+<?php
+
+use PHPUnit\Framework\TestCase;
+use App\Services\User\UserService;
+use App\DAO\Auth\UserDAO;
+use App\Models\User;
+
+class UserServiceRgrTest extends TestCase
+{
+    private UserService $userService;
+    private $dao;
+
+    protected function setUp(): void
+    {
+        $this->dao = $this->createMock(UserDAO::class);
+        $this->userService = new UserService($this->dao);
+    }
+
+    public function test_create_user_success()
+    {
+        $input = ['school_id' => 'S1', 'full_name' => 'Stu Dent', 'role' => 'student'];
+        $this->dao->method('schoolIdExists')->willReturn(false);
+        $this->dao->method('create')->willReturn(101);
+
+        $result = $this->userService->createUser($input);
+        $this->assertTrue($result['success']);
+        $this->assertSame(101, $result['user_id']);
+    }
+
+    public function test_create_user_fails_when_school_id_exists()
+    {
+        $input = ['school_id' => 'S1', 'full_name' => 'Stu Dent', 'role' => 'student'];
+        $this->dao->method('schoolIdExists')->willReturn(true);
+
+        $result = $this->userService->createUser($input);
+        $this->assertFalse($result['success']);
+    }
+
+    public function test_update_user_success()
+    {
+        $existing = new User(['user_id' => 1, 'school_id' => 'S1', 'full_name' => 'X', 'role' => 'student']);
+        $this->dao->method('findById')->willReturn($existing);
+        $this->dao->method('schoolIdExists')->willReturn(false);
+        $this->dao->method('update')->willReturn(true);
+
+        $result = $this->userService->updateUser(1, ['full_name' => 'Y']);
+        $this->assertTrue($result['success']);
+    }
+
+    public function test_update_user_fails_when_not_found()
+    {
+        $this->dao->method('findById')->willReturn(null);
+        $result = $this->userService->updateUser(999, ['full_name' => 'Z']);
+        $this->assertFalse($result['success']);
+    }
+
+    public function test_delete_user_success()
+    {
+        $existing = new User(['user_id' => 1, 'school_id' => 'S1']);
+        $this->dao->method('findById')->willReturn($existing);
+        $this->dao->method('delete')->willReturn(true);
+
+        $result = $this->userService->deleteUser(1);
+        $this->assertTrue($result['success']);
+    }
+}
+```
+
+#### Integration: AdminController (selected flows)
+```php
+<?php
+
+use PHPUnit\Framework\TestCase;
+use App\Controllers\Admin\AdminController;
+
+class AdminControllerRgrTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (session_status() === PHP_SESSION_NONE) session_start();
+        $_SESSION = ['user_id' => 1, 'role' => 'admin'];
+        $_SERVER['SCRIPT_NAME'] = '/index.php';
+    }
+
+    public function test_dashboard_renders_student_faculty_lists()
+    {
+        $controller = new AdminController();
+        ob_start();
+        $controller->dashboard();
+        $html = ob_get_clean();
+        $this->assertStringContainsString('Dashboard', $html);
+    }
+
+    public function test_add_user_post_redirects_back()
+    {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $controller = new AdminController();
+        ob_start();
+        $controller->addUser();
+        ob_end_clean();
+        $this->assertTrue(true);
+    }
+}
+```
+
+### 🟢 GREEN Phase: Make Tests Pass
+
+Minimal service logic example:
+```php
+public function createUser(array $data): array
+{
+    $user = new User($data);
+    if ($this->userDAO->schoolIdExists($user->getSchoolId())) {
+        return ['success' => false, 'message' => 'School ID already exists.'];
+    }
+    $id = $this->userDAO->create($user);
+    return $id ? ['success' => true, 'user_id' => $id, 'message' => 'User created successfully'] :
+                 ['success' => false, 'message' => 'Failed to create user'];
+}
+```
+
+### 🔵 REFACTOR Phase: Production Code
+
+- Validate via `User::validate()`
+- Generate and hash default passwords
+- Transactions when needed
+- Convert models to arrays for views via `usersToArray()`
+- Use session messages for UX feedback
+- Prepared statements in DAO; return `User` models consistently
+
+---
+
+## Feature 3: Role-Based Dashboard Access
+
+### 🔴 RED Phase: Write Failing Tests
+
+#### Unit/Service: Role Enforcement
+```php
+<?php
+
+use PHPUnit\Framework\TestCase;
+use App\Services\Auth\AuthService;
+
+class RoleAccessRgrTest extends TestCase
+{
+    private AuthService $auth;
+
+    protected function setUp(): void
+    {
+        $this->auth = new AuthService();
+        if (session_status() === PHP_SESSION_NONE) session_start();
+        $_SESSION = [];
+        $_SERVER['SCRIPT_NAME'] = '/index.php';
+    }
+
+    public function test_require_auth_redirects_when_not_logged_in()
+    {
+        $this->expectOutputRegex('/.*/');
+        try {
+            $this->auth->requireAuth();
+            $this->fail('Expected exit');
+        } catch (\Throwable $e) {
+            $this->assertTrue(true);
+        }
+    }
+
+    public function test_require_role_redirects_when_role_mismatch()
+    {
+        $_SESSION['user_id'] = 1;
+        $_SESSION['role'] = 'student';
+        $this->expectOutputRegex('/.*/');
+        try {
+            $this->auth->requireRole('admin');
+            $this->fail('Expected exit');
+        } catch (\Throwable $e) {
+            $this->assertTrue(true);
+        }
+    }
+
+    public function test_get_current_user_returns_array()
+    {
+        $_SESSION = ['user_id' => 1, 'school_id' => 'S1', 'full_name' => 'X', 'role' => 'student'];
+        $user = $this->auth->getCurrentUser();
+        $this->assertSame('student', $user['role']);
+    }
+
+    public function test_show_login_redirects_when_authenticated()
+    {
+        $_SESSION = ['user_id' => 1, 'role' => 'faculty', 'school_id' => 'F1', 'full_name' => 'Fac U Lty'];
+        $controller = new \App\Controllers\Auth\AuthController();
+        ob_start();
+        $controller->showLogin();
+        ob_end_clean();
+        $this->assertTrue(true);
+    }
+
+    public function test_invalid_role_clears_session_to_avoid_loops()
+    {
+        $_SESSION = ['user_id' => 1, 'role' => 'weird'];
+        $controller = new \App\Controllers\Auth\AuthController();
+        ob_start();
+        $controller->showLogin();
+        $out = ob_get_clean();
+        $this->assertStringContainsString('invalid', $out);
+        $this->assertArrayNotHasKey('role', $_SESSION);
+    }
+}
+```
+
+### 🟢 GREEN Phase: Make Tests Pass
+
+- `requireAuth()` and `requireRole()` redirect to `/login` when needed.
+- `AuthController::showLogin()` redirects when authenticated.
+- Switch-case dashboard routing per role.
+
+### 🔵 REFACTOR Phase: Production Code
+
+- Base-path aware redirects using `dirname($_SERVER['SCRIPT_NAME'])`.
+- On invalid role: logout, show login with error.
+- Instantiate `AdminController`/`FacultyController` lazily inside routes to avoid constructor-time redirects on `/login`.
+
+---
+
+## Shared Testing/Configuration
+
+phpunit.xml
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php" colors="true">
+    <testsuites>
+        <testsuite name="Unit">
+            <directory>tests/Unit</directory>
+        </testsuite>
+        <testsuite name="Integration">
+            <directory>tests/Integration</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>
+```
+
+tests/bootstrap.php
+```php
+<?php
+require __DIR__ . '/../vendor/autoload.php';
+
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+```
+
+composer.json (key sections)
+```json
+{
+  "require": {
+    "php": ">=8.1",
+    "ext-pdo": "*"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^10.5"
+  },
+  "autoload": {
+    "psr-4": {
+      "App\\": "src/"
+    }
+  }
+}
+```
+
+Database migration (MySQL)
+```sql
+CREATE TABLE IF NOT EXISTS users (
+  user_id INT AUTO_INCREMENT PRIMARY KEY,
+  school_id VARCHAR(64) NOT NULL UNIQUE,
+  full_name VARCHAR(255) NOT NULL,
+  password VARCHAR(255) NULL,
+  role ENUM('admin','faculty','student') NOT NULL,
+  year_level VARCHAR(16) NULL,
+  section VARCHAR(16) NULL,
+  created_at TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+```
+
+Command to run tests
+```bash
+./vendor/bin/phpunit -c phpunit.xml
+```
+
+---
+
+## TDD Benefits Observed
+- Clear separation of concerns enforced by tests (Model vs DAO vs Service vs Controller).
+- Early discovery of redirect loops and base-path issues through integration tests.
+- Safer refactors: switching from arrays to `User` models across layers validated by tests.
+- Regression protection for role-based access and session handling.
+
+## Integration with IDE (Cursor/PHPStorm)
+- Use test watcher to run unit tests on save.
+- Navigate between failing tests and code under test quickly.
+- Generate coverage to identify untested paths (e.g., invalid roles branch).
+- Record test sessions when iterating redirect logic or session behavior.
+
+## Next Steps and Recommendations
+- Expand negative DAO tests with an ephemeral test database (e.g., SQLite in-memory) and fixtures.
+- Add CSRF protection for login and admin actions.
+- Add password reset/change flows with TDD.
+- Add logging abstraction for auth failures and admin actions.
+- Introduce end-to-end smoke tests (e.g., Codeception) for login and dashboard navigation.
+- Enforce base-path-safe redirects uniformly through a small URL helper.
+
+Notes for stability:
+- Instantiate `AdminController`/`FacultyController` lazily in routes.
+- Use base-path redirects `dirname($_SERVER['SCRIPT_NAME'])` for `/login` and dashboards.
+- On invalid/unknown role, logout and render login with error.

--- a/README.unit-features.md
+++ b/README.unit-features.md
@@ -1,0 +1,382 @@
+# PHP Examination System - Unit Test RGR for Current Working Features
+
+Scope: Unit tests only (no integration/e2e). This guide documents Red-Green-Refactor (RGR) cycles for the features currently present in the codebase, based on `FEATURES.md` and the routing/controllers.
+
+Features covered:
+- Authentication (Login API + session handling)
+- Role-Based Dashboards (Admin, Faculty, Student placeholder)
+- Admin User Management (CRUD via service)
+- Logout Flows (API + confirmation pages logic via service)
+- Routing/Base-Path Behavior (Router normalization helpers)
+
+---
+
+## 1) Authentication (Login API + Session)
+User Story: "As a user, I want to log in with school_id and password."
+
+### 🔴 RED (Unit Tests)
+`tests/Unit/Auth/AuthService.LoginRgrTest.php`
+```php
+<?php
+
+use PHPUnit\Framework\TestCase;
+use App\Services\Auth\AuthService;
+use App\DAO\Auth\UserDAO;
+use App\Models\User;
+
+class AuthService_LoginRgrTest extends TestCase
+{
+    private AuthService $auth;
+    private $dao;
+
+    protected function setUp(): void
+    {
+        if (session_status() === PHP_SESSION_ACTIVE) session_destroy();
+        $_SESSION = [];
+        $this->dao = $this->createMock(UserDAO::class);
+        $this->auth = new AuthService($this->dao);
+    }
+
+    public function test_success_sets_session_and_returns_user(): void
+    {
+        $user = new User([
+            'user_id' => 1,
+            'school_id' => 'S1',
+            'full_name' => 'Alice Admin',
+            'role' => 'admin',
+            'password' => password_hash('pw', PASSWORD_BCRYPT)
+        ]);
+        $this->dao->method('authenticate')->willReturn($user);
+
+        $result = $this->auth->login('S1', 'pw');
+
+        $this->assertTrue($result['success']);
+        $this->assertSame('admin', $_SESSION['role'] ?? null);
+        $this->assertSame('S1', $_SESSION['school_id'] ?? null);
+    }
+
+    public function test_wrong_password_fails(): void
+    {
+        $user = new User(['password' => password_hash('pw', PASSWORD_BCRYPT)]);
+        $this->dao->method('authenticate')->willReturn($user);
+
+        $result = $this->auth->login('S1', 'nope');
+        $this->assertFalse($result['success']);
+        $this->assertSame('Invalid School ID or password.', $result['message']);
+    }
+
+    public function test_user_not_found_fails(): void
+    {
+        $this->dao->method('authenticate')->willReturn(null);
+        $result = $this->auth->login('NONE', 'pw');
+        $this->assertFalse($result['success']);
+        $this->assertSame('User not found.', $result['message']);
+    }
+
+    public function test_empty_credentials_fail(): void
+    {
+        $this->assertFalse($this->auth->login('', 'pw')['success']);
+        $this->assertFalse($this->auth->login('S1', '')['success']);
+        $this->assertFalse($this->auth->login('', '')['success']);
+    }
+
+    public function test_is_authenticated_true_when_session_has_user_and_role(): void
+    {
+        $_SESSION = ['user_id' => 9, 'role' => 'faculty'];
+        $this->assertTrue($this->auth->isAuthenticated());
+    }
+}
+```
+
+Model password verification (recommended):
+`tests/Unit/Models/User.PasswordRgrTest.php`
+```php
+<?php
+
+use PHPUnit\Framework\TestCase;
+use App\Models\User;
+
+class User_PasswordRgrTest extends TestCase
+{
+    public function test_verify_password_hashed_and_plain(): void
+    {
+        $plain = 'pw';
+        $user = new User(['password' => password_hash($plain, PASSWORD_BCRYPT)]);
+        $this->assertTrue($user->verifyPassword($plain));
+        $this->assertFalse($user->verifyPassword('nope'));
+
+        $user2 = new User(['password' => 'pw']);
+        $this->assertTrue($user2->verifyPassword('pw'));
+    }
+}
+```
+
+### 🟢 GREEN (Minimum to Pass)
+- `AuthService::login()` trims, fetches model from DAO, uses `User::verifyPassword()`, sets session keys.
+- `User::verifyPassword()` supports `password_verify()` and plaintext fallback.
+
+### 🔵 REFACTOR
+- Extract session writes to a helper for easier testing.
+- Add logging hooks for failed logins (mockable).
+- Keep DAO returning `User` models.
+
+---
+
+## 2) Role-Based Dashboards (Access Control)
+User Story: "As a user, I access my role-specific dashboard after login."
+
+### 🔴 RED (Unit Tests)
+`tests/Unit/Auth/AccessControlRgrTest.php`
+```php
+<?php
+
+use PHPUnit\Framework\TestCase;
+use App\Services\Auth\AuthService;
+
+class AccessControlRgrTest extends TestCase
+{
+    private AuthService $auth;
+
+    protected function setUp(): void
+    {
+        $this->auth = new AuthService();
+        if (session_status() === PHP_SESSION_NONE) session_start();
+        $_SESSION = [];
+        $_SERVER['SCRIPT_NAME'] = '/index.php';
+    }
+
+    public function test_require_auth_redirects_when_not_logged_in(): void
+    {
+        $this->expectOutputRegex('/.*/');
+        try {
+            $this->auth->requireAuth();
+            $this->fail('Expected exit');
+        } catch (\Throwable $e) {
+            $this->assertTrue(true);
+        }
+    }
+
+    public function test_require_role_redirects_on_mismatch(): void
+    {
+        $_SESSION = ['user_id' => 1, 'role' => 'student'];
+        $this->expectOutputRegex('/.*/');
+        try {
+            $this->auth->requireRole('admin');
+            $this->fail('Expected exit');
+        } catch (\Throwable $e) {
+            $this->assertTrue(true);
+        }
+    }
+
+    public function test_get_current_user_returns_array(): void
+    {
+        $_SESSION = ['user_id' => 2, 'school_id' => 'F1', 'full_name' => 'Fac U Lty', 'role' => 'faculty'];
+        $user = $this->auth->getCurrentUser();
+        $this->assertSame('faculty', $user['role']);
+    }
+}
+```
+
+### 🟢 GREEN
+- Ensure `requireAuth()`/`requireRole()` perform base-path-aware redirects to `/login`.
+- `getCurrentUser()` reads from session.
+
+### 🔵 REFACTOR
+- Centralize role constants and a simple policy class.
+- Provide a pure function for base-path computation (injectable/mocked).
+
+---
+
+## 3) Admin User Management (CRUD)
+User Story: "As an admin, I can add, edit, and delete users."
+
+### 🔴 RED (Unit Tests)
+`tests/Unit/User/UserService.CrudRgrTest.php`
+```php
+<?php
+
+use PHPUnit\Framework\TestCase;
+use App\Services\User\UserService;
+use App\DAO\Auth\UserDAO;
+use App\Models\User;
+
+class UserService_CrudRgrTest extends TestCase
+{
+    private UserService $service;
+    private $dao;
+
+    protected function setUp(): void
+    {
+        $this->dao = $this->createMock(UserDAO::class);
+        $this->service = new UserService($this->dao);
+    }
+
+    public function test_create_user_success(): void
+    {
+        $input = ['school_id' => 'S1', 'full_name' => 'Stu Dent', 'role' => 'student'];
+        $this->dao->method('schoolIdExists')->willReturn(false);
+        $this->dao->method('create')->willReturn(101);
+        $result = $this->service->createUser($input);
+        $this->assertTrue($result['success']);
+        $this->assertSame(101, $result['user_id']);
+    }
+
+    public function test_create_user_fails_when_duplicate_school_id(): void
+    {
+        $input = ['school_id' => 'S1', 'full_name' => 'Stu Dent', 'role' => 'student'];
+        $this->dao->method('schoolIdExists')->willReturn(true);
+        $result = $this->service->createUser($input);
+        $this->assertFalse($result['success']);
+    }
+
+    public function test_update_user_success(): void
+    {
+        $existing = new User(['user_id' => 1, 'school_id' => 'S1', 'full_name' => 'X', 'role' => 'student']);
+        $this->dao->method('findById')->willReturn($existing);
+        $this->dao->method('schoolIdExists')->willReturn(false);
+        $this->dao->method('update')->willReturn(true);
+        $result = $this->service->updateUser(1, ['full_name' => 'Y']);
+        $this->assertTrue($result['success']);
+    }
+
+    public function test_update_user_fails_when_not_found(): void
+    {
+        $this->dao->method('findById')->willReturn(null);
+        $result = $this->service->updateUser(999, ['full_name' => 'Z']);
+        $this->assertFalse($result['success']);
+    }
+
+    public function test_delete_user_success(): void
+    {
+        $existing = new User(['user_id' => 1, 'school_id' => 'S1']);
+        $this->dao->method('findById')->willReturn($existing);
+        $this->dao->method('delete')->willReturn(true);
+        $result = $this->service->deleteUser(1);
+        $this->assertTrue($result['success']);
+    }
+}
+```
+
+### 🟢 GREEN
+- `UserService::createUser()` checks uniqueness then calls `create()`.
+- `updateUser()` loads, merges, checks uniqueness on school_id change, calls `update()`.
+- `deleteUser()` ensures existence then calls `delete()`.
+
+### 🔵 REFACTOR
+- Validate inputs via `User::validate()`.
+- Generate/hash default passwords where applicable.
+- Keep returns simple structs to ease unit assertions; convert to arrays at the view adapter layer.
+
+---
+
+## 4) Logout Flows (Service-Level Behavior)
+User Story: "As a user, I can logout and invalidate my session."
+
+### 🔴 RED (Unit Tests)
+`tests/Unit/Auth/AuthService.LogoutRgrTest.php`
+```php
+<?php
+
+use PHPUnit\Framework\TestCase;
+use App\Services\Auth\AuthService;
+
+class AuthService_LogoutRgrTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (session_status() === PHP_SESSION_NONE) session_start();
+        $_SESSION = ['user_id' => 1, 'role' => 'admin'];
+    }
+
+    public function test_logout_clears_session_and_returns_success(): void
+    {
+        $auth = new AuthService();
+        $result = $auth->logout();
+        $this->assertTrue($result['success']);
+        $this->assertSame([], $_SESSION);
+    }
+}
+```
+
+### 🟢 GREEN
+- `AuthService::logout()` clears `$_SESSION`, destroys cookie, and returns success.
+
+### 🔵 REFACTOR
+- Consider invalidating other session storage (e.g., server-side stores) if added later.
+
+---
+
+## 5) Routing/Base-Path Behavior (Pure Helpers)
+User Story: "As a developer, I want requests to resolve correctly regardless of subdirectory or public/ docroot."
+
+Unit-test strategy: Extract a pure helper that normalizes a path given `REQUEST_URI` and `SCRIPT_NAME` and test it in isolation.
+
+### 🔴 RED (Unit Tests)
+`tests/Unit/Core/RouterPathHelperRgrTest.php`
+```php
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../helpers/PathHelper.php';
+
+class RouterPathHelperRgrTest extends TestCase
+{
+    public function test_strips_script_dir(): void
+    {
+        $normalized = \App\Core\PathHelper::normalize('/myapp/login', '/myapp/public/index.php');
+        $this->assertSame('/login', $normalized);
+    }
+
+    public function test_strips_parent_of_public(): void
+    {
+        $normalized = \App\Core\PathHelper::normalize('/myapp/public/login', '/myapp/public/index.php');
+        $this->assertSame('/login', $normalized);
+    }
+
+    public function test_root_becomes_slash(): void
+    {
+        $normalized = \App\Core\PathHelper::normalize('/', '/index.php');
+        $this->assertSame('/', $normalized);
+    }
+}
+```
+
+### 🟢 GREEN
+Implement minimal `PathHelper::normalize(string $requestPath, string $scriptName): string` mirroring the logic in `Router`.
+
+### 🔵 REFACTOR
+- Reuse this helper inside `Router` to reduce duplication and to keep router path logic unit-testable.
+
+---
+
+## PHPUnit Config (Unit Only) and Commands
+phpunit.xml
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php" colors="true">
+    <testsuites>
+        <testsuite name="Unit">
+            <directory>tests/Unit</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>
+```
+
+tests/bootstrap.php
+```php
+<?php
+require __DIR__ . '/../vendor/autoload.php';
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+```
+
+Run unit tests:
+```bash
+./vendor/bin/phpunit -c phpunit.xml --testsuite Unit
+```
+
+Notes:
+- Use PHPUnit mocks for DAOs to isolate Service logic.
+- For redirect/exit flows, unit tests should assert behavior via try/catch or by extracting pure helpers for redirect target computation.

--- a/README.unit-features.md
+++ b/README.unit-features.md
@@ -88,37 +88,70 @@ class AuthService_LoginRgrTest extends TestCase
 }
 ```
 
-Model password verification (recommended):
-`tests/Unit/Models/User.PasswordRgrTest.php`
+### 🟢 GREEN (Minimum to Pass)
+Minimal `User::verifyPassword()` and `AuthService::login()` (aligned with your code):
 ```php
-<?php
-
-use PHPUnit\Framework\TestCase;
-use App\Models\User;
-
-class User_PasswordRgrTest extends TestCase
+// src/App/Models/User.php
+public function verifyPassword(string $plain): bool
 {
-    public function test_verify_password_hashed_and_plain(): void
-    {
-        $plain = 'pw';
-        $user = new User(['password' => password_hash($plain, PASSWORD_BCRYPT)]);
-        $this->assertTrue($user->verifyPassword($plain));
-        $this->assertFalse($user->verifyPassword('nope'));
-
-        $user2 = new User(['password' => 'pw']);
-        $this->assertTrue($user2->verifyPassword('pw'));
+    $hashed = $this->password ?? '';
+    if ($hashed && password_get_info($hashed)['algo']) {
+        return password_verify($plain, $hashed);
     }
+    return $plain === $hashed || $plain === ($this->plain_password ?? '');
+}
+```
+```php
+// src/App/Services/Auth/AuthService.php
+public function login($school_id, $password)
+{
+    if (empty(trim($school_id)) || empty(trim($password))) {
+        return ['success' => false, 'message' => 'School ID and password are required.'];
+    }
+    $school_id = trim($school_id);
+    $password = trim($password);
+
+    $user = $this->userDAO->authenticate($school_id, $password);
+    if (!$user) {
+        return ['success' => false, 'message' => 'User not found.'];
+    }
+    if (!$user->verifyPassword($password)) {
+        return ['success' => false, 'message' => 'Invalid School ID or password.'];
+    }
+
+    if (session_status() === PHP_SESSION_NONE) session_start();
+    $_SESSION['user_id'] = $user->getUserId();
+    $_SESSION['school_id'] = $user->getSchoolId();
+    $_SESSION['full_name'] = $user->getFullName();
+    $_SESSION['role'] = $user->getRole();
+    $_SESSION['year_level'] = $user->getYearLevel();
+    $_SESSION['section'] = $user->getSection();
+
+    return [
+        'success' => true,
+        'message' => 'Login successful!',
+        'user' => $user->toArray(),
+    ];
 }
 ```
 
-### 🟢 GREEN (Minimum to Pass)
-- `AuthService::login()` trims, fetches model from DAO, uses `User::verifyPassword()`, sets session keys.
-- `User::verifyPassword()` supports `password_verify()` and plaintext fallback.
-
-### 🔵 REFACTOR
-- Extract session writes to a helper for easier testing.
-- Add logging hooks for failed logins (mockable).
-- Keep DAO returning `User` models.
+### 🔵 REFACTOR (Production-Ready)
+- Extract base-path redirect calc and session write into helpers (testable).
+- Add logging hooks; broaden validation.
+Example refactor extract:
+```php
+// src/App/Services/Auth/AuthService.php
+private function writeSessionFromUser(User $user): void
+{
+    if (session_status() === PHP_SESSION_NONE) session_start();
+    $_SESSION['user_id'] = $user->getUserId();
+    $_SESSION['school_id'] = $user->getSchoolId();
+    $_SESSION['full_name'] = $user->getFullName();
+    $_SESSION['role'] = $user->getRole();
+    $_SESSION['year_level'] = $user->getYearLevel();
+    $_SESSION['section'] = $user->getSection();
+}
+```
 
 ---
 
@@ -178,12 +211,45 @@ class AccessControlRgrTest extends TestCase
 ```
 
 ### 🟢 GREEN
-- Ensure `requireAuth()`/`requireRole()` perform base-path-aware redirects to `/login`.
-- `getCurrentUser()` reads from session.
+Key methods (already present and aligned):
+```php
+// src/App/Services/Auth/AuthService.php
+public function isAuthenticated()
+{
+    if (session_status() === PHP_SESSION_NONE) session_start();
+    return isset($_SESSION['user_id']) && isset($_SESSION['role']);
+}
+
+public function requireAuth()
+{
+    if (!$this->isAuthenticated()) {
+        $scriptName = $_SERVER['SCRIPT_NAME'];
+        $basePath = dirname($scriptName);
+        header('Location: ' . $basePath . '/login');
+        exit;
+    }
+    return ['success' => true, 'message' => 'User is authenticated.'];
+}
+
+public function requireRole($requiredRole)
+{
+    $authResult = $this->requireAuth();
+    if (!$authResult['success']) return $authResult;
+
+    $user = $this->getCurrentUser();
+    if (!$user || !isset($user['role']) || $user['role'] !== $requiredRole) {
+        $scriptName = $_SERVER['SCRIPT_NAME'];
+        $basePath = dirname($scriptName);
+        header('Location: ' . $basePath . '/login');
+        exit;
+    }
+    return ['success' => true, 'message' => 'User has required role.'];
+}
+```
 
 ### 🔵 REFACTOR
-- Centralize role constants and a simple policy class.
-- Provide a pure function for base-path computation (injectable/mocked).
+- Extract base-path resolver to a pure helper (e.g., `UrlHelper::basePath()`), inject for easier testing.
+- Centralize role constants and policies.
 
 ---
 
@@ -258,14 +324,51 @@ class UserService_CrudRgrTest extends TestCase
 ```
 
 ### 🟢 GREEN
-- `UserService::createUser()` checks uniqueness then calls `create()`.
-- `updateUser()` loads, merges, checks uniqueness on school_id change, calls `update()`.
-- `deleteUser()` ensures existence then calls `delete()`.
+Minimal service logic (aligned with your implementation):
+```php
+// src/App/Services/User/UserService.php
+public function createUser(array $userData): array
+{
+    $user = new User($userData);
+    if ($this->userDAO->schoolIdExists($user->getSchoolId())) {
+        return ['success' => false, 'message' => 'School ID already exists'];
+    }
+    $userId = $this->userDAO->create($user);
+    return $userId
+        ? ['success' => true, 'message' => 'User created successfully', 'user_id' => $userId]
+        : ['success' => false, 'message' => 'Failed to create user'];
+}
+
+public function updateUser($userId, array $userData): array
+{
+    $existing = $this->userDAO->findById($userId);
+    if (!$existing) {
+        return ['success' => false, 'message' => 'User not found'];
+    }
+    $user = new User(array_merge($existing->toArray(), $userData));
+    if (isset($userData['school_id']) && $userData['school_id'] !== $existing->getSchoolId()) {
+        if ($this->userDAO->schoolIdExists($userData['school_id'], $userId)) {
+            return ['success' => false, 'message' => 'School ID already exists.'];
+        }
+    }
+    $ok = $this->userDAO->update($userId, $user);
+    return ['success' => $ok, 'message' => $ok ? 'User updated successfully' : 'Failed to update user'];
+}
+
+public function deleteUser($userId): array
+{
+    $existing = $this->userDAO->findById($userId);
+    if (!$existing) {
+        return ['success' => false, 'message' => 'User not found'];
+    }
+    $ok = $this->userDAO->delete($userId);
+    return ['success' => $ok, 'message' => $ok ? 'User deleted successfully' : 'Failed to delete user'];
+}
+```
 
 ### 🔵 REFACTOR
-- Validate inputs via `User::validate()`.
-- Generate/hash default passwords where applicable.
-- Keep returns simple structs to ease unit assertions; convert to arrays at the view adapter layer.
+- Use `User::validate()`; normalize names/school IDs; generate default hashed password when creating students.
+- Keep service methods thin, delegate persistence to DAO; keep model authoritative for business rules.
 
 ---
 
@@ -299,17 +402,30 @@ class AuthService_LogoutRgrTest extends TestCase
 ```
 
 ### 🟢 GREEN
-- `AuthService::logout()` clears `$_SESSION`, destroys cookie, and returns success.
+```php
+// src/App/Services/Auth/AuthService.php
+public function logout()
+{
+    if (session_status() === PHP_SESSION_NONE) {
+        session_start();
+    }
+    $_SESSION = [];
+    if (ini_get('session.use_cookies')) {
+        $params = session_get_cookie_params();
+        setcookie(session_name(), '', time() - 42000, $params['path'], $params['domain'], $params['secure'], $params['httponly']);
+    }
+    session_destroy();
+    return ['success' => true, 'message' => 'Logged out successfully'];
+}
+```
 
 ### 🔵 REFACTOR
-- Consider invalidating other session storage (e.g., server-side stores) if added later.
+- Hook into centralized session manager if introduced later; add logging.
 
 ---
 
 ## 5) Routing/Base-Path Behavior (Pure Helpers)
 User Story: "As a developer, I want requests to resolve correctly regardless of subdirectory or public/ docroot."
-
-Unit-test strategy: Extract a pure helper that normalizes a path given `REQUEST_URI` and `SCRIPT_NAME` and test it in isolation.
 
 ### 🔴 RED (Unit Tests)
 `tests/Unit/Core/RouterPathHelperRgrTest.php`
@@ -343,10 +459,36 @@ class RouterPathHelperRgrTest extends TestCase
 ```
 
 ### 🟢 GREEN
-Implement minimal `PathHelper::normalize(string $requestPath, string $scriptName): string` mirroring the logic in `Router`.
+```php
+// tests/helpers/PathHelper.php (example helper for unit tests)
+namespace App\Core;
+
+final class PathHelper
+{
+    public static function normalize(string $requestPath, string $scriptName): string
+    {
+        $path = rtrim($requestPath, '/');
+        if ($path === '') $path = '/';
+        $scriptDir = dirname($scriptName);
+        $parentDir = rtrim(dirname($scriptDir), '/');
+        $candidates = array_unique(array_filter([
+            $scriptDir,
+            $parentDir && substr($scriptDir, -7) === '/public' ? $parentDir : null,
+        ]));
+        foreach ($candidates as $base) {
+            if ($base !== '/' && $base !== '.' && str_starts_with($path, $base)) {
+                $path = substr($path, strlen($base));
+                if ($path === '') $path = '/';
+                break;
+            }
+        }
+        return $path;
+    }
+}
+```
 
 ### 🔵 REFACTOR
-- Reuse this helper inside `Router` to reduce duplication and to keep router path logic unit-testable.
+- Replace duplicated logic in `Router` with calls to this helper; unit tests remain green while integration becomes simpler.
 
 ---
 

--- a/README.unit-tests.md
+++ b/README.unit-tests.md
@@ -1,0 +1,382 @@
+# PHP Examination System - TDD Red-Green-Refactor (Unit Tests Only)
+
+## Scope
+- This document focuses exclusively on UNIT tests (no integration/e2e).
+- Architecture: MVC + DAO + Service Layer (unit tests target Models, DAOs with doubles, and Services).
+- Tools: PHPUnit.
+
+## Table of Contents
+- Feature 1: User Authentication (Service and Model)
+- Feature 2: Admin User Management (Service)
+- Feature 3: Role-Based Access (Service)
+- PHPUnit Config and Commands
+
+---
+
+## Feature 1: User Authentication System (Unit)
+User Story: "As a user (admin/faculty/student), I want to login with school_id and password"
+
+### 🔴 RED Phase (Failing Unit Tests)
+Create `tests/Unit/Auth/AuthServiceRgrTest.php`:
+```php
+<?php
+
+use PHPUnit\Framework\TestCase;
+use App\Services\Auth\AuthService;
+use App\DAO\Auth\UserDAO;
+use App\Models\User;
+
+class AuthServiceRgrTest extends TestCase
+{
+    private AuthService $authService;
+    private $userDAOMock;
+
+    protected function setUp(): void
+    {
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_destroy();
+        }
+        $_SESSION = [];
+
+        $this->userDAOMock = $this->createMock(UserDAO::class);
+        $this->authService = new AuthService($this->userDAOMock);
+    }
+
+    public function test_login_success_sets_session_and_returns_user(): void
+    {
+        $user = new User([
+            'user_id' => 10,
+            'school_id' => 'A123',
+            'full_name' => 'Alice Admin',
+            'role' => 'admin',
+            'password' => password_hash('secret', PASSWORD_BCRYPT),
+        ]);
+
+        $this->userDAOMock->method('authenticate')
+            ->with('A123', 'secret')
+            ->willReturn($user);
+
+        $result = $this->authService->login('A123', 'secret');
+
+        $this->assertTrue($result['success']);
+        $this->assertSame('admin', $_SESSION['role'] ?? null);
+        $this->assertSame('A123', $_SESSION['school_id'] ?? null);
+    }
+
+    public function test_login_fails_for_wrong_password(): void
+    {
+        $user = new User([
+            'user_id' => 10,
+            'school_id' => 'A123',
+            'full_name' => 'Alice Admin',
+            'role' => 'admin',
+            'password' => password_hash('secret', PASSWORD_BCRYPT),
+        ]);
+
+        $this->userDAOMock->method('authenticate')->willReturn($user);
+
+        $result = $this->authService->login('A123', 'bad');
+
+        $this->assertFalse($result['success']);
+        $this->assertSame('Invalid School ID or password.', $result['message']);
+    }
+
+    public function test_login_fails_when_user_not_found(): void
+    {
+        $this->userDAOMock->method('authenticate')->willReturn(null);
+
+        $result = $this->authService->login('NONE', 'pw');
+
+        $this->assertFalse($result['success']);
+        $this->assertSame('User not found.', $result['message']);
+    }
+
+    public function test_login_fails_when_empty_credentials(): void
+    {
+        $this->assertFalse($this->authService->login('', 'pw')['success']);
+        $this->assertFalse($this->authService->login('id', '')['success']);
+        $this->assertFalse($this->authService->login('', '')['success']);
+    }
+
+    public function test_require_auth_redirects_when_not_authenticated(): void
+    {
+        $this->expectOutputRegex('/.*/');
+        try {
+            $this->authService->requireAuth();
+            $this->fail('Expected exit in requireAuth');
+        } catch (\Throwable $e) {
+            $this->assertTrue(true);
+        }
+    }
+}
+```
+
+Model unit test for password verification (optional but recommended) in `tests/Unit/Models/UserRgrTest.php`:
+```php
+<?php
+
+use PHPUnit\Framework\TestCase;
+use App\Models\User;
+
+class UserRgrTest extends TestCase
+{
+    public function test_verify_password_supports_hashed(): void
+    {
+        $plain = 'pw';
+        $user = new User(['password' => password_hash($plain, PASSWORD_BCRYPT)]);
+        $this->assertTrue($user->verifyPassword($plain));
+        $this->assertFalse($user->verifyPassword('nope'));
+    }
+}
+```
+
+Expected (initial) failures will indicate missing behaviors and ensure we implement only what’s necessary.
+
+### 🟢 GREEN Phase (Minimal Code to Pass)
+- Ensure `AuthService::login()` trims inputs, calls DAO `authenticate()`, uses `User::verifyPassword()`, sets `$_SESSION` keys, returns success structure.
+- Ensure `User::verifyPassword()` supports `password_verify()` and fallback plaintext match.
+
+Example minimal methods (already present in your codebase, shown here as reference):
+```php
+// In App\Models\User
+public function verifyPassword(string $plain): bool
+{
+    $hashed = $this->password ?? '';
+    if ($hashed && password_get_info($hashed)['algo']) {
+        return password_verify($plain, $hashed);
+    }
+    return $plain === $hashed || $plain === ($this->plain_password ?? '');
+}
+```
+```php
+// In App\Services\Auth\AuthService
+public function login($school_id, $password)
+{
+    if (empty(trim($school_id)) || empty(trim($password))) {
+        return ['success' => false, 'message' => 'School ID and password are required.'];
+    }
+    $user = $this->userDAO->authenticate(trim($school_id), trim($password));
+    if (!$user) {
+        return ['success' => false, 'message' => 'User not found.'];
+    }
+    if (!$user->verifyPassword($password)) {
+        return ['success' => false, 'message' => 'Invalid School ID or password.'];
+    }
+    if (session_status() === PHP_SESSION_NONE) session_start();
+    $_SESSION['user_id'] = $user->getUserId();
+    $_SESSION['school_id'] = $user->getSchoolId();
+    $_SESSION['full_name'] = $user->getFullName();
+    $_SESSION['role'] = $user->getRole();
+    $_SESSION['year_level'] = $user->getYearLevel();
+    $_SESSION['section'] = $user->getSection();
+
+    return ['success' => true, 'message' => 'Login successful!', 'user' => $user->toArray()];
+}
+```
+
+### 🔵 REFACTOR Phase (Harden While Keeping Tests Green)
+- Add more granular messages as constants or a translator.
+- Extract session write operations into a small method for testability.
+- Ensure DAO strictly returns `User` models.
+- Add logging hooks for failures (mockable in unit tests).
+
+---
+
+## Feature 2: Admin User Management (Unit)
+User Story: "As an admin, I want to create, edit, and delete users (students/faculty)"
+
+### 🔴 RED Phase (Failing Unit Tests)
+Create `tests/Unit/User/UserServiceRgrTest.php`:
+```php
+<?php
+
+use PHPUnit\Framework\TestCase;
+use App\Services\User\UserService;
+use App\DAO\Auth\UserDAO;
+use App\Models\User;
+
+class UserServiceRgrTest extends TestCase
+{
+    private UserService $userService;
+    private $dao;
+
+    protected function setUp(): void
+    {
+        $this->dao = $this->createMock(UserDAO::class);
+        $this->userService = new UserService($this->dao);
+    }
+
+    public function test_create_user_success(): void
+    {
+        $input = ['school_id' => 'S1', 'full_name' => 'Stu Dent', 'role' => 'student'];
+        $this->dao->method('schoolIdExists')->willReturn(false);
+        $this->dao->method('create')->willReturn(101);
+
+        $result = $this->userService->createUser($input);
+        $this->assertTrue($result['success']);
+        $this->assertSame(101, $result['user_id']);
+    }
+
+    public function test_create_user_fails_when_school_id_exists(): void
+    {
+        $input = ['school_id' => 'S1', 'full_name' => 'Stu Dent', 'role' => 'student'];
+        $this->dao->method('schoolIdExists')->willReturn(true);
+
+        $result = $this->userService->createUser($input);
+        $this->assertFalse($result['success']);
+    }
+
+    public function test_update_user_success(): void
+    {
+        $existing = new User(['user_id' => 1, 'school_id' => 'S1', 'full_name' => 'X', 'role' => 'student']);
+        $this->dao->method('findById')->willReturn($existing);
+        $this->dao->method('schoolIdExists')->willReturn(false);
+        $this->dao->method('update')->willReturn(true);
+
+        $result = $this->userService->updateUser(1, ['full_name' => 'Y']);
+        $this->assertTrue($result['success']);
+    }
+
+    public function test_update_user_fails_when_not_found(): void
+    {
+        $this->dao->method('findById')->willReturn(null);
+        $result = $this->userService->updateUser(999, ['full_name' => 'Z']);
+        $this->assertFalse($result['success']);
+    }
+
+    public function test_delete_user_success(): void
+    {
+        $existing = new User(['user_id' => 1, 'school_id' => 'S1']);
+        $this->dao->method('findById')->willReturn($existing);
+        $this->dao->method('delete')->willReturn(true);
+
+        $result = $this->userService->deleteUser(1);
+        $this->assertTrue($result['success']);
+    }
+}
+```
+
+### 🟢 GREEN Phase (Minimal Code to Pass)
+- `createUser()` returns failure if `schoolIdExists()` is true; otherwise calls `create()` and returns new ID.
+- `updateUser()` loads `findById()`, merges updates, checks uniqueness when school_id changes; calls `update()`.
+- `deleteUser()` verifies existence then calls `delete()`.
+
+Typical minimal implementations (your codebase already follows this pattern).
+
+### 🔵 REFACTOR Phase
+- Validate using `User::validate()`.
+- Hash default passwords for students.
+- Convert returned `User` models to arrays for view adapters only (keep service returns orthogonal and easy to test).
+
+---
+
+## Feature 3: Role-Based Dashboard Access (Unit)
+User Story: "As a user, I want to access my role-specific dashboard after login"
+
+### 🔴 RED Phase (Failing Unit Tests)
+Create `tests/Unit/Auth/RoleAccessRgrTest.php`:
+```php
+<?php
+
+use PHPUnit\Framework\TestCase;
+use App\Services\Auth\AuthService;
+
+class RoleAccessRgrTest extends TestCase
+{
+    private AuthService $auth;
+
+    protected function setUp(): void
+    {
+        $this->auth = new AuthService();
+        if (session_status() === PHP_SESSION_NONE) session_start();
+        $_SESSION = [];
+        $_SERVER['SCRIPT_NAME'] = '/index.php';
+    }
+
+    public function test_require_auth_redirects_when_not_logged_in(): void
+    {
+        $this->expectOutputRegex('/.*/');
+        try {
+            $this->auth->requireAuth();
+            $this->fail('Expected exit');
+        } catch (\Throwable $e) {
+            $this->assertTrue(true);
+        }
+    }
+
+    public function test_require_role_redirects_when_role_mismatch(): void
+    {
+        $_SESSION['user_id'] = 1;
+        $_SESSION['role'] = 'student';
+        $this->expectOutputRegex('/.*/');
+        try {
+            $this->auth->requireRole('admin');
+            $this->fail('Expected exit');
+        } catch (\Throwable $e) {
+            $this->assertTrue(true);
+        }
+    }
+
+    public function test_get_current_user_returns_array(): void
+    {
+        $_SESSION = ['user_id' => 1, 'school_id' => 'S1', 'full_name' => 'X', 'role' => 'student'];
+        $user = $this->auth->getCurrentUser();
+        $this->assertSame('student', $user['role']);
+    }
+
+    public function test_is_authenticated_false_when_no_session(): void
+    {
+        $_SESSION = [];
+        $this->assertFalse($this->auth->isAuthenticated());
+    }
+
+    public function test_is_authenticated_true_when_session_has_user_and_role(): void
+    {
+        $_SESSION = ['user_id' => 2, 'role' => 'faculty'];
+        $this->assertTrue($this->auth->isAuthenticated());
+    }
+}
+```
+
+### 🟢 GREEN Phase (Minimal Code to Pass)
+- `requireAuth()` and `requireRole()` perform base-path-aware redirects.
+- `getCurrentUser()` returns array from session; `isAuthenticated()` checks required keys.
+
+These are already implemented in your `AuthService`.
+
+### 🔵 REFACTOR Phase
+- Make base path computation a helper method for reuse and easier unit testing (pure function receiving globals).
+- Centralize role constants and policy checks in a small policy class to simplify unit testing.
+
+---
+
+## PHPUnit Config and Commands (Unit only)
+phpunit.xml
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php" colors="true">
+    <testsuites>
+        <testsuite name="Unit">
+            <directory>tests/Unit</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>
+```
+
+tests/bootstrap.php
+```php
+<?php
+require __DIR__ . '/../vendor/autoload.php';
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+```
+
+Run unit tests:
+```bash
+./vendor/bin/phpunit -c phpunit.xml --testsuite Unit
+```
+
+Notes:
+- Use PHPUnit mocks for DAO (`UserDAO`) to isolate Service and Model behavior.
+- Avoid testing headers directly in unit tests; instead assert that the redirect conditions lead to exit (caught via try/catch) or expose small methods to compute redirect targets which can be asserted.

--- a/public/index.php
+++ b/public/index.php
@@ -14,6 +14,7 @@ $router = new Router();
 
 // Create controllers
 $authController = new AuthController();
+// Lazy-instantiate protected controllers inside route handlers to avoid auth redirects on /login
 $adminController = new AdminController();
 $facultyController = new FacultyController();
 
@@ -42,21 +43,21 @@ $router->post('/api/auth/logout', function() use ($authController) {
 });
 
 // Admin Dashboard Routes
-$router->get('/admin/dashboard', function() use ($adminController) {
-    $adminController->dashboard();
+$router->get('/admin/dashboard', function() {
+    (new AdminController())->dashboard();
 });
 
-$router->get('/admin/logout', function() use ($adminController) {
-    $adminController->logout();
+$router->get('/admin/logout', function() {
+    (new AdminController())->logout();
 });
 
 // Faculty Dashboard Routes
-$router->get('/faculty/dashboard', function() use ($facultyController) {
-    $facultyController->dashboard();
+$router->get('/faculty/dashboard', function() {
+    (new FacultyController())->dashboard();
 });
 
-$router->get('/faculty/logout', function() use ($facultyController) {
-    $facultyController->logout();
+$router->get('/faculty/logout', function() {
+    (new FacultyController())->logout();
 });
 
 // Student success placeholder (until student dashboard exists)
@@ -68,41 +69,41 @@ $router->get('/student-success', function() {
 });
 
 // Admin User Management Routes
-$router->post('/admin/users/add', function() use ($adminController) {
-    $adminController->addUser();
+$router->post('/admin/users/add', function() {
+    (new AdminController())->addUser();
 });
 
-$router->post('/admin/users/add-student', function() use ($adminController) {
-    $adminController->addStudent();
+$router->post('/admin/users/add-student', function() {
+    (new AdminController())->addStudent();
 });
 
-$router->post('/admin/users/edit-student', function() use ($adminController) {
-    $adminController->editStudent();
+$router->post('/admin/users/edit-student', function() {
+    (new AdminController())->editStudent();
 });
 
-$router->post('/admin/users/edit/{id}', function($id) use ($adminController) {
-    $adminController->editUser($id);
+$router->post('/admin/users/edit/{id}', function($id) {
+    (new AdminController())->editUser($id);
 });
 
-$router->post('/admin/users/delete-student', function() use ($adminController) {
-    $adminController->deleteStudent();
+$router->post('/admin/users/delete-student', function() {
+    (new AdminController())->deleteStudent();
 });
 
 // Admin Faculty Management Routes
-$router->post('/admin/users/add-faculty', function() use ($adminController) {
-    $adminController->addFaculty();
+$router->post('/admin/users/add-faculty', function() {
+    (new AdminController())->addFaculty();
 });
 
-$router->post('/admin/users/edit-faculty', function() use ($adminController) {
-    $adminController->editFaculty();
+$router->post('/admin/users/edit-faculty', function() {
+    (new AdminController())->editFaculty();
 });
 
-$router->post('/admin/users/delete-faculty', function() use ($adminController) {
-    $adminController->deleteFaculty();
+$router->post('/admin/users/delete-faculty', function() {
+    (new AdminController())->deleteFaculty();
 });
 
-$router->post('/admin/users/delete/{id}', function($id) use ($adminController) {
-    $adminController->deleteUser($id);
+$router->post('/admin/users/delete/{id}', function($id) {
+    (new AdminController())->deleteUser($id);
 });
 
 // Handle the request

--- a/public/index.php
+++ b/public/index.php
@@ -14,9 +14,7 @@ $router = new Router();
 
 // Create controllers
 $authController = new AuthController();
-// Lazy-instantiate protected controllers inside route handlers to avoid auth redirects on /login
-$adminController = new AdminController();
-$facultyController = new FacultyController();
+// Protected controllers are instantiated lazily inside route handlers
 
 // Debug information (remove this later)
 $currentPath = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);

--- a/src/App/Controllers/Auth/AuthController.php
+++ b/src/App/Controllers/Auth/AuthController.php
@@ -24,7 +24,14 @@ class AuthController
         // If user is already logged in, redirect to appropriate dashboard
         if ($this->authService->isAuthenticated()) {
             $user = $this->authService->getCurrentUser();
-            $this->redirectToDashboard($user['role']);
+            $role = $user['role'] ?? null;
+            // Guard against invalid or missing roles to avoid redirect loops
+            if (!in_array($role, ['admin', 'faculty', 'student'], true)) {
+                $this->authService->logout();
+                $this->view->display('auth.login', ['error' => 'Your session role is invalid. Please log in again.']);
+                return;
+            }
+            $this->redirectToDashboard($role);
             return;
         }
 
@@ -112,7 +119,10 @@ class AuthController
                 header('Location: ' . $basePath . '/student-success');
                 break;
             default:
+                // Unknown role: clear session to avoid loops, then redirect to login
+                $this->authService->logout();
                 header('Location: ' . $basePath . '/login');
+                exit;
         }
         return;
     }

--- a/src/App/Core/Router.php
+++ b/src/App/Core/Router.php
@@ -65,11 +65,18 @@ class Router
 
         // Remove subdirectory from path if it exists
         $scriptName = $_SERVER['SCRIPT_NAME'];
-        $subdirectory = dirname($scriptName);
-        if ($subdirectory !== '/' && strpos($path, $subdirectory) === 0) {
-            $path = substr($path, strlen($subdirectory));
-            if (empty($path)) {
-                $path = '/';
+        $scriptDir = dirname($scriptName);
+        // If app is served from /.../public, also consider stripping the parent
+        $parentDir = rtrim(dirname($scriptDir), '/');
+        $candidates = array_unique(array_filter([
+            $scriptDir,
+            $parentDir && substr($scriptDir, -7) === '/public' ? $parentDir : null,
+        ]));
+        foreach ($candidates as $base) {
+            if ($base !== '/' && $base !== '.' && strpos($path, $base) === 0) {
+                $path = substr($path, strlen($base));
+                $path = $path === '' ? '/' : $path;
+                break;
             }
         }
 
@@ -107,12 +114,17 @@ class Router
         }
 
         $scriptName = $_SERVER['SCRIPT_NAME'] ?? '';
-        $subdirectory = dirname($scriptName);
-        
-        if ($subdirectory !== '/' && $subdirectory !== '.' && strpos($path, $subdirectory) === 0) {
-            $path = substr($path, strlen($subdirectory));
-            if ($path === '') {
-                $path = '/';
+        $scriptDir = dirname($scriptName);
+        $parentDir = rtrim(dirname($scriptDir), '/');
+        $candidates = array_unique(array_filter([
+            $scriptDir,
+            $parentDir && substr($scriptDir, -7) === '/public' ? $parentDir : null,
+        ]));
+        foreach ($candidates as $base) {
+            if ($base !== '/' && $base !== '.' && strpos($path, $base) === 0) {
+                $path = substr($path, strlen($base));
+                $path = $path === '' ? '/' : $path;
+                break;
             }
         }
 

--- a/tests/Unit/README.RGR.md
+++ b/tests/Unit/README.RGR.md
@@ -1,0 +1,196 @@
+# Unit Tests TDD: Red-Green-Refactor (RGR)
+
+This document maps your existing unit tests in `tests/Unit/` to a TDD (Red-Green-Refactor) narrative. It explains what each test file validates (RED), the minimal implementation that makes them pass (GREEN), and the hardening/refactors applied or recommended (REFACTOR).
+
+Run all unit tests:
+```bash
+./vendor/bin/phpunit -c phpunit.xml --testsuite Unit
+```
+
+Contents covered:
+- Auth/AuthServiceTest.php
+- Admin/AdminControllerTest.php
+- User/UserServiceTest.php
+- DAO/UserDAOTest.php
+- Models/UserTest.php
+- Core/RouterTest.php
+
+---
+
+## Auth/AuthServiceTest.php
+
+### 🔴 RED – What the tests enforce
+- Successful login with valid `school_id` + `password` returns success and sets session fields.
+- Failure on invalid password or non-existent user with clear messages.
+- Empty credentials are rejected.
+- `requireAuth()` redirects unauthenticated users to `/login`.
+- `requireRole()` redirects when the session role doesn’t match.
+
+### 🟢 GREEN – Minimal code that satisfies
+- `AuthService::login($school_id, $password)`:
+  - Trim inputs, fetch `User` via `UserDAO::authenticate()` (returns `User` model or null).
+  - Verify password with `User::verifyPassword()` (supports hashed and plain fallback).
+  - Start session and set `$_SESSION['user_id','school_id','full_name','role','year_level','section']`.
+  - Return a success payload with `user` array.
+- `AuthService::requireAuth()`/`requireRole($role)`:
+  - Use session to check authentication/authorization; header redirect to base-path `/login` and exit when failing.
+
+Example GREEN snippets (already implemented):
+```php
+// AuthService::isAuthenticated
+return isset($_SESSION['user_id']) && isset($_SESSION['role']);
+```
+```php
+// AuthService::requireAuth (base-path aware)
+$basePath = dirname($_SERVER['SCRIPT_NAME']);
+if (!$this->isAuthenticated()) { header('Location: ' . $basePath . '/login'); exit; }
+```
+
+### 🔵 REFACTOR – Hardening
+- Extract session write to a helper for easier test isolation.
+- Log failed authentication attempts.
+- Consolidate role constants and policies.
+
+---
+
+## Admin/AdminControllerTest.php
+
+### 🔴 RED – What the tests enforce
+- Construction requires authenticated `admin` (calls `requireAuth()` + `requireRole('admin')`).
+- `dashboard()` composes data using `UserService` and renders the admin view.
+- Actions (add/edit/delete for student/faculty) set success/error messages and redirect back to dashboard.
+- `logout` flow shows confirmation and performs redirect on `?confirm=true`.
+
+### 🟢 GREEN – Minimal code that satisfies
+- `__construct()`: instantiate `AuthService`, `UserService`, `View`; enforce auth and role.
+- `dashboard()`: fetch users by role via `UserService`, convert to arrays, render `admin.dashboard`.
+- POST handlers: call `UserService` methods; set `$_SESSION['success_message']|error_message`; redirect to dashboard.
+- `logout()`: if `confirm=true`, call `AuthService::logout()` then redirect to `/login`; otherwise render confirmation page.
+
+Example GREEN snippets:
+```php
+// AdminController::__construct
+$this->authService->requireAuth();
+$this->authService->requireRole('admin');
+```
+```php
+// Redirect to dashboard helper (base-path aware)
+$basePath = dirname($_SERVER['SCRIPT_NAME']);
+header('Location: ' . $basePath . '/admin/dashboard');
+```
+
+### 🔵 REFACTOR – Hardening
+- Extract view-model builders for dashboard.
+- Centralize redirect helper.
+- Add CSRF tokens for admin POST actions.
+
+---
+
+## User/UserServiceTest.php
+
+### 🔴 RED – What the tests enforce
+- `createUser` fails on duplicate `school_id`; succeeds otherwise and returns new `user_id`.
+- `updateUser` requires existing user; checks `school_id` uniqueness on change; returns success flag.
+- `deleteUser` requires existing user; returns success flag.
+- Query helpers: `getAllUsers`, `getUsersByRole`, `getStudentsByYearSection`, `getUserBy(School)Id` return `User` models.
+
+### 🟢 GREEN – Minimal code that satisfies
+- Use `UserDAOInterface` that returns `User` models.
+- `createUser()`:
+  - Create `User` model from data; check `schoolIdExists`; call `create()`; return outcome with `user_id`.
+- `updateUser()`:
+  - Load `findById`; merge into `User` model; if `school_id` changed, check uniqueness; call `update()`.
+- `deleteUser()`:
+  - Load `findById`; call `delete()`; return outcome.
+
+Example GREEN snippet:
+```php
+if (isset($data['school_id']) && $data['school_id'] !== $existing->getSchoolId()) {
+    if ($this->userDAO->schoolIdExists($data['school_id'], $userId)) {
+        return ['success' => false, 'message' => 'School ID already exists.'];
+    }
+}
+```
+
+### 🔵 REFACTOR – Hardening
+- Delegate validation to `User::validate()`; generate and hash default passwords for students.
+- Keep service returns simple structs for testability; adapt to arrays at the view layer.
+
+---
+
+## DAO/UserDAOTest.php
+
+### 🔴 RED – What the tests enforce
+- DAO uses the `Database` singleton and `PDO` prepared statements.
+- Retrieval methods return `User` model instances (not arrays): `findById`, `findBySchoolId`, `getAllUsers`, `getUsersByRole`, `getStudentsByYearSection`.
+- `create(User)` returns new ID; `update($id, User)`/`delete($id)` return bool.
+- `schoolIdExists($schoolId, $excludeId)` behaves correctly.
+
+### 🟢 GREEN – Minimal code that satisfies
+- Implement data access with prepared statements and map rows to `User` models:
+```php
+$stmt = $pdo->prepare('SELECT * FROM users WHERE school_id = ?');
+$stmt->execute([$schoolId]);
+$row = $stmt->fetch(PDO::FETCH_ASSOC);
+return $row ? new User($row) : null;
+```
+- `create(User $u)`: insert and return `lastInsertId()` cast to int.
+
+### 🔵 REFACTOR – Hardening
+- Handle `PDOException` with safe fallbacks; avoid leaking DB errors.
+- Add pagination to list queries if needed later.
+
+---
+
+## Models/UserTest.php
+
+### 🔴 RED – What the tests enforce
+- `User` supports hydration, serialization (`hydrate()`, `toArray()`), getters/setters.
+- Business methods such as `verifyPassword()`, `hashPassword()`, `generateDefaultPassword()` behave consistently.
+- `validate()` returns structured errors for invalid inputs.
+
+### 🟢 GREEN – Minimal code that satisfies
+- Implement the `User` model with business logic centralization:
+```php
+public function toArray(): array { /* map all properties */ }
+public function verifyPassword(string $plain): bool { /* password_verify or fallback */ }
+public function hashPassword(string $plain): string { return password_hash($plain, PASSWORD_BCRYPT); }
+```
+
+### 🔵 REFACTOR – Hardening
+- Enforce invariants in setters; normalize names; keep validation rules cohesive and test-backed.
+
+---
+
+## Core/RouterTest.php
+
+### 🔴 RED – What the tests enforce
+- Route registration for `GET/POST/PUT/DELETE` works.
+- `dispatch()`/`handleRequest()` resolve routes correctly, including parameterized paths and query strings.
+- Router normalizes paths (trailing slash removal, subdirectory stripping, including `public/` parent stripping) to match registered routes.
+- 404 behavior when no route matches.
+
+### 🟢 GREEN – Minimal code that satisfies
+- Maintain a `$routes` map keyed by method and path.
+- Normalize `$path` from `REQUEST_URI`, strip base path using `dirname($_SERVER['SCRIPT_NAME'])` and its parent if script dir ends with `/public`.
+- Match exact and parameterized routes; invoke callbacks.
+
+Example GREEN snippet:
+```php
+$scriptDir = dirname($_SERVER['SCRIPT_NAME']);
+$parentDir = rtrim(dirname($scriptDir), '/');
+$candidates = array_unique(array_filter([$scriptDir, substr($scriptDir, -7) === '/public' ? $parentDir : null]));
+foreach ($candidates as $base) {
+    if ($base && $base !== '/' && strpos($path, $base) === 0) { $path = substr($path, strlen($base)) ?: '/'; break; }
+}
+```
+
+### 🔵 REFACTOR – Hardening
+- Extract a pure `PathHelper::normalize()` and reuse in `Router` to keep path logic unit-testable.
+- Add logging around routing decisions (guarded by env flag) to assist debugging.
+
+---
+
+## Notes
+- All GREEN snippets above align with your existing implementation; use them as reference for mapping tests to code.
+- REFACTOR items are recommendations. Implement incrementally with new unit tests to keep changes safe.


### PR DESCRIPTION
Lazy-instantiate `AdminController` and `FacultyController` to resolve the login redirect loop.

Previously, `AdminController` and `FacultyController` were instantiated at application bootstrap in `public/index.php`. Their constructors, which include authentication and role checks (`requireAuth()`/`requireRole()`), would trigger a redirect to `/login` even when the user was already trying to access `/login`, resulting in an infinite 302 redirect loop.

---
<a href="https://cursor.com/background-agent?bcId=bc-55beb646-f193-4c21-8b55-fc8c9c795ef8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-55beb646-f193-4c21-8b55-fc8c9c795ef8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

